### PR TITLE
Adds Promise.defer() for router.js compatibility

### DIFF
--- a/Promise.js
+++ b/Promise.js
@@ -1,12 +1,12 @@
 (function(global) {
 	if(global.Promise) return;
-	
+
 	if(typeof module !== 'undefined' && module.exports) {
 		module.exports = Promise;
 	} else {
 		global.Promise = Promise;
 	}
-	
+
 	var asap = (global && global.setImmediate) || function(fn){ setTimeout(fn, 0) };
 	function bind(fn, thisArg) {
 		return function() {
@@ -168,5 +168,14 @@
 		});
 	};
 
-	
+	Promise.defer = function (label) {
+		var deferred = {};
+
+		deferred.promise = new Promise(function(resolve, reject) {
+			deferred.resolve = resolve;
+			deferred.reject = reject;
+		}, label);
+
+		return deferred;
+	}
 })(this);


### PR DESCRIPTION
I'm [looking for a simple Promise implementation for using with router.js](https://github.com/tildeio/router.js/issues/82), first I've looked at `then/promise` but has features (nodejs related) I don't need for.

Actually, router.js is using `RSVP.defer()` for some internal handling, after patching this everything seems to be working perfectly.

What do you think?
