### PR TITLE
Increase compatiblity with faking time in test tools

### DIFF
--- a/Promise.js
+++ b/Promise.js
@@ -1,4 +1,7 @@
 (function(root) {
+    // Store setTimeout reference so promise-polyfill will be unaffected by
+    // other code modifying setTimeout (like sinon.useFakeTimers())
+	var setTimeout = setTimeout;
 
 	// Use polyfill for setImmediate for performance gains
 	var asap = (typeof setImmediate === 'function' && setImmediate) ||


### PR DESCRIPTION
By caching reference to the global setImmediate and setTimeout we can ensure
that promise-polyfill still works as excpected when using fake timers in unit test scenarios.

See

* https://github.com/sinonjs/sinon/blob/master/docs/current/fake-timers.md
* http://jstest.jcoglan.com/timers.html

