### PR TITLE
Fix setTimeout shadowing logic

### DIFF
--- a/Promise.js
+++ b/Promise.js
@@ -2,11 +2,11 @@
 
 	// Store setTimeout reference so promise-polyfill will be unaffected by
 	// other code modifying setTimeout (like sinon.useFakeTimers())
-	var setTimeout = setTimeout;
+	var setTimeoutFunc = setTimeout;
 
 	// Use polyfill for setImmediate for performance gains
 	var asap = (typeof setImmediate === 'function' && setImmediate) ||
-		function(fn) { setTimeout(fn, 1); };
+		function(fn) { setTimeoutFunc(fn, 1); };
 
 	// Polyfill for Function.prototype.bind
 	function bind(fn, thisArg) {


### PR DESCRIPTION
The change in [1] is meant to shadow window.setTimeout, but it needs
a fix: the right operand cannot have the same name as the left
operand as in this case, the variable is assigned `undefined`.

This went undetected by the build because the unit tests currently run only in node, which has a `setImmediate` so the function at line 9 in https://github.com/taylorhakes/promise-polyfill/blob/master/Promise.js#L8-L9 is never executed.