### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "Taylor Hakes"
   ],
   "description": "Lightweight promise polyfill for the browser and node. A+ Compliant.",
-  "main": "Promise.js",
+  "main": "promise.js",
   "moduleType": [
     "globals",
     "node"


### PR DESCRIPTION
change of case as bower wiredep doesn't add promise.js if it has an uppercase P