### PR TITLE
Added the ability to subclass based on the constructor 'then' calls

### DIFF
--- a/promise.js
+++ b/promise.js
@@ -144,8 +144,7 @@
   };
 
   Promise.prototype.then = function (onFulfilled, onRejected) {
-    var ctor = this.constructor,
-      prom = new (ctor !== Promise ? ctor : Promise)(noop);
+    var prom = new (this.constructor)(noop);
 
     handle(this, new Handler(onFulfilled, onRejected, prom));
     return prom;

--- a/promise.js
+++ b/promise.js
@@ -101,7 +101,7 @@
         }
       }, 1);
     }
-    
+
     for (var i = 0, len = self._deferreds.length; i < len; i++) {
       handle(self, self._deferreds[i]);
     }
@@ -144,7 +144,9 @@
   };
 
   Promise.prototype.then = function (onFulfilled, onRejected) {
-    var prom = new Promise(noop);
+    var ctor = this.constructor,
+      prom = new (ctor !== Promise ? ctor : Promise)(noop);
+
     handle(this, new Handler(onFulfilled, onRejected, prom));
     return prom;
   };
@@ -214,7 +216,7 @@
   Promise._setImmediateFn = function _setImmediateFn(fn) {
     asap = fn;
   };
-  
+
   Promise._setUnhandledRejectionFn = function _setUnhandledRejectionFn(fn) {
     onUnhandledRejection = fn;
   };

--- a/test/promise.js
+++ b/test/promise.js
@@ -15,7 +15,7 @@ describe('Promise', function () {
     });
     it('changes immediate fn', function () {
       var spy = sinon.spy();
-  
+
       function immediateFn(fn) {
         spy();
         fn();
@@ -32,19 +32,19 @@ describe('Promise', function () {
     });
     it('changes immediate fn multiple', function () {
       var spy1 = sinon.spy();
-  
+
       function immediateFn1(fn) {
         spy1();
         fn();
       }
-  
+
       var spy2 = sinon.spy();
-  
+
       function immediateFn2(fn) {
         spy2();
         fn();
       }
-  
+
       Promise._setImmediateFn(immediateFn1);
       var done = false;
       new Promise(function (resolve) {
@@ -137,7 +137,7 @@ describe('Promise', function () {
     it('promise reject error late', function (done) {
       var prom = Promise.reject('hello');
       prom.catch(function() {
-        
+
       });
       setTimeout(function() {
         assert(!stub.called);
@@ -150,6 +150,30 @@ describe('Promise', function () {
         assert.equal(stub.args[0][1], 'hello');
         done();
       }, 50);
+    });
+  });
+  describe('Promise.prototype.then', function() {
+    function Subclass() {
+      Promise.apply(this, arguments);
+    }
+
+    Object.setPrototypeOf(Subclass.prototype, Promise.prototype);
+
+    it('subclassed Promise resolves to subclass', function() {
+      var prom = new Subclass(function(resolve) {
+        resolve();
+      }).then(function() {
+        assert(prom instanceof Subclass);
+      });
+    });
+    it('subclassed Promise rejects to subclass', function() {
+      var spy = sinon.spy(),
+        prom = new Subclass(function(_, reject) {
+          reject();
+        }).then(spy, function() {
+          assert(spy.not.called);
+          assert(prom instanceof Subclass);
+        });
     });
   });
 }); 

--- a/test/promise.js
+++ b/test/promise.js
@@ -153,25 +153,34 @@ describe('Promise', function () {
     });
   });
   describe('Promise.prototype.then', function() {
+    var spy1 = sinon.spy();
+
     function Subclass() {
+      spy1();
       Promise.apply(this, arguments);
     }
 
     Object.setPrototypeOf(Subclass.prototype, Promise.prototype);
 
+    Subclass.prototype.then = function() {
+      return Promise.prototype.then.apply(this, arguments);
+    };
+
     it('subclassed Promise resolves to subclass', function() {
       var prom = new Subclass(function(resolve) {
         resolve();
       }).then(function() {
+        assert(spy1.called);
         assert(prom instanceof Subclass);
       });
     });
     it('subclassed Promise rejects to subclass', function() {
-      var spy = sinon.spy(),
+      var spy2 = sinon.spy(),
         prom = new Subclass(function(_, reject) {
           reject();
-        }).then(spy, function() {
-          assert(spy.not.called);
+        }).then(spy2, function() {
+          assert(spy1.called);
+          assert(spy2.not.called);
           assert(prom instanceof Subclass);
         });
     });

--- a/test/promise.js
+++ b/test/promise.js
@@ -19,7 +19,7 @@ describe('Promise', function () {
       function immediateFn(fn) {
         spy();
         fn();
-      };
+      }
       Promise._setImmediateFn(immediateFn);
       var done = false;
       new Promise(function (resolve) {
@@ -153,36 +153,36 @@ describe('Promise', function () {
     });
   });
   describe('Promise.prototype.then', function() {
-    var spy1 = sinon.spy();
+    var spy,
+        SubClass;
+    beforeEach(function() {
+      spy = sinon.spy();
+      SubClass = function() {
+        spy();
+        Promise.apply(this, arguments);
+      };
 
-    function Subclass() {
-      spy1();
-      Promise.apply(this, arguments);
-    }
+      function __() { this.constructor = SubClass; }
+      __.prototype = Promise.prototype;
+      SubClass.protptype = new __();
 
-    Object.setPrototypeOf(Subclass.prototype, Promise.prototype);
-
-    Subclass.prototype.then = function() {
-      return Promise.prototype.then.apply(this, arguments);
-    };
-
+      SubClass.prototype.then = function() {
+        return Promise.prototype.then.apply(this, arguments);
+      };
+    });
     it('subclassed Promise resolves to subclass', function() {
-      var prom = new Subclass(function(resolve) {
+      var prom = new SubClass(function(resolve) {
         resolve();
-      }).then(function() {
-        assert(spy1.called);
-        assert(prom instanceof Subclass);
-      });
+      }).then(function() {}, function() {});
+      assert(spy.calledTwice);
+      assert(prom instanceof SubClass);
     });
     it('subclassed Promise rejects to subclass', function() {
-      var spy2 = sinon.spy(),
-        prom = new Subclass(function(_, reject) {
-          reject();
-        }).then(spy2, function() {
-          assert(spy1.called);
-          assert(spy2.not.called);
-          assert(prom instanceof Subclass);
-        });
+      var prom = new SubClass(function(_, reject) {
+        reject();
+      }).then(function() {}, function() {});
+      assert(spy.calledTwice);
+      assert(prom instanceof SubClass);
     });
   });
 }); 


### PR DESCRIPTION
If the constructor of the subclass instance who's `then` method is called is not the Promise constructor, call the constructor of the subclass instance.