### PR TITLE
Promise.prototype.finally

### DIFF
--- a/promise.js
+++ b/promise.js
@@ -143,6 +143,21 @@
     return this.then(null, onRejected);
   };
 
+  Promise.prototype['finally'] = function (onAny) {
+    return this.then(
+      function (value) {
+        return Promise.resolve(onAny()).then(function () {
+          return value;
+        });
+      },
+      function (reason) {
+        return Promise.resolve(onAny()).then(function () {
+          throw reason;
+        });
+      }
+    );
+  };
+
   Promise.prototype.then = function (onFulfilled, onRejected) {
     var prom = new (this.constructor)(noop);
 

--- a/promise.js
+++ b/promise.js
@@ -144,14 +144,15 @@
   };
 
   Promise.prototype['finally'] = function (onAny) {
+    var constructor = this.constructor;
     return this.then(
       function (value) {
-        return Promise.resolve(onAny()).then(function () {
+        return constructor.resolve(onAny()).then(function () {
           return value;
         });
       },
       function (reason) {
-        return Promise.resolve(onAny()).then(function () {
+        return constructor.resolve(onAny()).then(function () {
           throw reason;
         });
       }

--- a/test/promise.js
+++ b/test/promise.js
@@ -5,6 +5,62 @@ var adapter = require('./adapter');
 describe("Promises/A+ Tests", function () {
   require("promises-aplus-tests").mocha(adapter);
 });
+describe('Promise.prototype.finally', function () {
+  it('is called when promise is resolved', function (done) {
+    var spy = sinon.spy();
+    Promise.resolve().finally(spy);
+    setTimeout(function () {
+      assert(spy.called);
+      done();
+    }, 50);
+  });
+  it('is called when promise is rejected', function (done) {
+    var spy = sinon.spy();
+    Promise.reject().finally(spy);
+    setTimeout(function () {
+      assert(spy.called);
+      done();
+    }, 50);
+  });
+  it('promise is still rejected', function (done) {
+    var spy = sinon.spy();
+    Promise.reject().finally(function () { }).catch(spy);
+    setTimeout(function () {
+      assert(spy.called);
+      done();
+    }, 50);
+  });
+  it('passes original resolved value', function (done) {
+    var spy = sinon.spy();
+    Promise.resolve("original").finally(function () {
+      return "changed";
+    }).then(spy);
+    setTimeout(function () {
+      assert(spy.calledWith("original"));
+      done();
+    }, 50);
+  });
+  it('can reject', function (done) {
+    var spy = sinon.spy();
+    Promise.resolve().finally(function () {
+      return Promise.reject();
+    }).catch(spy);
+    setTimeout(function () {
+      assert(spy.called);
+      done();
+    }, 50);
+  });
+  it('can reject rejected promise with new reason', function (done) {
+    var spy = sinon.spy();
+    Promise.reject("original").finally(function () {
+      return Promise.reject("changed");
+    }).catch(spy);
+    setTimeout(function () {
+      assert(spy.calledWith("changed"));
+      done();
+    }, 50);
+  });
+});
 describe('Promise', function () {
   describe('Promise._setImmediateFn', function () {
     afterEach(function() {


### PR DESCRIPTION
Implemented it accoding to http://www.2ality.com/2014/10/es6-promises-api.html

It isn't in the spec though

Also see:
https://esdiscuss.org/topic/proposal-promise-prototype-finally
https://esdiscuss.org/topic/why-the-ecmascript-2015-promises-don-t-have-finally-methods
https://github.com/domenic/promises-unwrapping/issues/18
https://github.com/getify/You-Dont-Know-JS/blob/master/async%20&%20performance/ch3.md#finally

Someone arguing against it:
https://github.com/domenic/promises-unwrapping/issues/18#issuecomment-63504016