### PR TITLE
Fix README markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
     <img src="http://promises-aplus.github.com/promises-spec/assets/logo-small.png"
          align="right" alt="Promises/A+ logo" />
 </a>
+
 # Promise Polyfill
 [![travis][travis-image]][travis-url]
 


### PR DESCRIPTION
Two newlines are required for most markdown implementations to consider something to be on a new line.