### PR TITLE
Add jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ npm install promise-polyfill --save-exact
 ```
 bower install promise-polyfill
 ```
+### CDN Use
+```
+<script href="https://cdn.jsdelivr.net/npm/promise-polyfill@6/promise.min.js"></script>
+```
 
 ## Downloads
 


### PR DESCRIPTION
I added a jsDelivr link to your Readme so it is easier to use, [jsDelivr](https://www.jsdelivr.com/) is  also the [fastest opensource CDN](https://www.cdnperf.com/) available and built specifically for production usage.