### PR TITLE
Bring back module entry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "7.0.2",
   "description": "Lightweight promise polyfill. A+ compliant",
   "main": "lib/index.js",
+  "module": "src/index.js",
   "jsnext:main": "src/index.js",
   "unpkg": "dist/promise.min.js",
   "files": [


### PR DESCRIPTION
Not sure why [this commit](https://github.com/taylorhakes/promise-polyfill/commit/906f19b6c37163bf38878e60f2528fcb7ec992b7) has removed it.

`jsnext:main` and `module` are the same field (meaning that their goal is the same). `jsnext:main` was renamed to `module` and latter is more standard, some tools understands both of them, some need additional configuration to pick up `jsnext:main` at all and some already even have dropped `jsnext:main` support. 

To sum it up - `jsnext:main` is older and considered being a legacy field. `module` is the one that should prevail, although packages might have both to support wider range of tools and their various versions.