### PR TITLE
Adding Promise.prototype.finally

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -144,9 +144,6 @@ Promise.prototype.then = function(onFulfilled, onRejected) {
 };
 
 Promise.prototype['finally'] = function(callback) {
-  if (typeof callback !== 'function') {
-    return this;
-  }
   var constructor = this.constructor;
   return this.then(
     function(value) {

--- a/src/index.js
+++ b/src/index.js
@@ -143,7 +143,10 @@ Promise.prototype.then = function(onFulfilled, onRejected) {
   return prom;
 };
 
-Promise.prototype.finally = function(callback) {
+Promise.prototype['finally'] = function(callback) {
+  if (typeof callback !== 'function') {
+    return this;
+  }
   var constructor = this.constructor;
   return this.then(
     function(value) {

--- a/src/index.js
+++ b/src/index.js
@@ -143,6 +143,19 @@ Promise.prototype.then = function(onFulfilled, onRejected) {
   return prom;
 };
 
+Promise.prototype.finally = function(callback) {
+  var constructor = this.constructor;
+  return this.then(function (value) {
+    return constructor.resolve(callback()).then(function() {
+		  return value;
+		});
+  }, function (reason) {
+    return constructor.resolve(callback()).then(function() {
+      return constructor.reject(reason);
+    });
+  }
+}
+
 Promise.all = function(arr) {
   return new Promise(function(resolve, reject) {
     if (!arr || typeof arr.length === 'undefined')

--- a/src/index.js
+++ b/src/index.js
@@ -153,7 +153,7 @@ Promise.prototype.finally = function(callback) {
     return constructor.resolve(callback()).then(function() {
       return constructor.reject(reason);
     });
-  }
+  });
 }
 
 Promise.all = function(arr) {

--- a/src/index.js
+++ b/src/index.js
@@ -145,16 +145,19 @@ Promise.prototype.then = function(onFulfilled, onRejected) {
 
 Promise.prototype.finally = function(callback) {
   var constructor = this.constructor;
-  return this.then(function (value) {
-    return constructor.resolve(callback()).then(function() {
-		  return value;
-		});
-  }, function (reason) {
-    return constructor.resolve(callback()).then(function() {
-      return constructor.reject(reason);
-    });
-  });
-}
+  return this.then(
+    function(value) {
+      return constructor.resolve(callback()).then(function() {
+        return value;
+      });
+    },
+    function(reason) {
+      return constructor.resolve(callback()).then(function() {
+        return constructor.reject(reason);
+      });
+    }
+  );
+};
 
 Promise.all = function(arr) {
   return new Promise(function(resolve, reject) {

--- a/test/promise.js
+++ b/test/promise.js
@@ -252,10 +252,13 @@ describe('Promise', function() {
             });
         })
         .then(function() {
-          log(4);
+          log.push('4');
         })
         .then(function() {
           assert.deepEqual(log, [1, 2, 3, 4], 'Correct order of promise chain');
+        })
+        .catch(function(err) {
+          assert(false, err);
         })
         .finally(done);
     });

--- a/test/promise.js
+++ b/test/promise.js
@@ -191,6 +191,62 @@ describe('Promise', function() {
       assert(prom instanceof SubClass);
     });
   });
+  describe('Promise.prototype.finally', function() {
+    it('should be called', function(done) {
+      var called = false;
+      Promise.resolve().finally(function() {
+        called = true;
+      });
+      setTimeout(function() {
+        assert(called, 'Finally handler was called');
+        done();
+      }, 50);
+    });
+
+    it('should be called on success', function(done) {
+      Promise.resolve(3).finally(function() {
+        assert(true, 'Finally handler was called');
+        done();
+      });
+    });
+
+    it('should be called on failure', function(done) {
+      Promise.reject(new Error()).finally(function() {
+        assert(true, 'Finally handler was called');
+        done();
+      });
+    });
+
+    it('should not affect the result', function(done) {
+      Promise.resolve(3)
+        .finally(function() {
+          return 'dummy';
+        })
+        .then(function(result) {
+          assert.equal(result, 3, 'Result was the resolved result');
+          return Promise.reject(new Error('test'));
+        })
+        .finally(function() {
+          return 'dummy';
+        })
+        .catch(function(reason) {
+          assert(!!reason, 'There was a reason');
+          assert.equal(reason.message, 'test', 'We catched the correct error');
+        })
+        .finally(done);
+    });
+
+    it('should reject with the handler error if handler throws', function(done) {
+      Promise.reject(new Error('test2'))
+        .finally(function() {
+          throw new Error('test3');
+        })
+        .catch(function(reason) {
+          assert.equal(reason.message, 'test3', 'The handler error was caught');
+        })
+        .finally(done);
+    });
+  });
   describe('Promise.all', function() {
     it('throws on implicit undefined', function() {
       return Promise.all().then(

--- a/test/promise.js
+++ b/test/promise.js
@@ -252,7 +252,7 @@ describe('Promise', function() {
             });
         })
         .then(function() {
-          log.push('4');
+          log.push(4);
         })
         .then(function() {
           assert.deepEqual(log, [1, 2, 3, 4], 'Correct order of promise chain');

--- a/test/promise.js
+++ b/test/promise.js
@@ -192,27 +192,16 @@ describe('Promise', function() {
     });
   });
   describe('Promise.prototype.finally', function() {
-    it('should be called', function(done) {
-      var called = false;
-      Promise.resolve().finally(function() {
-        called = true;
-      });
-      setTimeout(function() {
-        assert(called, 'Finally handler was called');
-        done();
-      }, 50);
-    });
-
     it('should be called on success', function(done) {
       Promise.resolve(3).finally(function() {
-        assert(true, 'Finally handler was called');
+        assert.equal(arguments.length, 0, 'No arguments to onFinally');
         done();
       });
     });
 
     it('should be called on failure', function(done) {
       Promise.reject(new Error()).finally(function() {
-        assert(true, 'Finally handler was called');
+        assert.equal(arguments.length, 0, 'No arguments to onFinally');
         done();
       });
     });
@@ -246,7 +235,32 @@ describe('Promise', function() {
         })
         .finally(done);
     });
+
+    it('should await any promise returned from the callback', function(done) {
+      var log = [];
+      Promise.resolve()
+        .then(function() {
+          log.push(1);
+        })
+        .finally(function() {
+          return Promise.resolve()
+            .then(function() {
+              log.push(2);
+            })
+            .then(function() {
+              log.push(3);
+            });
+        })
+        .then(function() {
+          log(4);
+        })
+        .then(function() {
+          assert.deepEqual(log, [1, 2, 3, 4], 'Correct order of promise chain');
+        })
+        .finally(done);
+    });
   });
+
   describe('Promise.all', function() {
     it('throws on implicit undefined', function() {
       return Promise.all().then(


### PR DESCRIPTION
This PR adds Promise.prototype.finally (as it is now part of ES2018).

~~**Please test and verify it is functional before merging!**~~ I've added tests, so it should be fine to merge.

The code is mostly copied from https://github.com/matthew-andrews/Promise.prototype.finally/blob/master/finally.js