### PR TITLE
Don't shadow global variable

### DIFF
--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -1,6 +1,6 @@
 import Promise from './index';
 
-var global = (function() {
+var globalNS = (function() {
   // the only reliable means to get the global object is
   // `Function('return this')()`
   // However, this causes CSP violations in Chrome apps.
@@ -16,6 +16,6 @@ var global = (function() {
   throw new Error('unable to locate global object');
 })();
 
-if (!global.Promise) {
-  global.Promise = Promise;
+if (!globalNS.Promise) {
+  globalNS.Promise = Promise;
 }


### PR DESCRIPTION
On Node.js I am getting following exception:

```
  throw new Error('unable to locate global object');
```

As I understand what happens is that you first redeclare `global` variable using `var global` and later check its type via `typeof global` which always returns undefined.