### PR TITLE
Bump bower.js to 8.1.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "promise-polyfill",
-  "version": "7.1.0",
+  "version": "8.1.0",
   "homepage": "https://github.com/taylorhakes/promise-polyfill",
   "authors": [
     "Taylor Hakes"


### PR DESCRIPTION
Resolve mismatch:

`bower promise-polyfill#*      mismatch Version declared in the json (7.1.0) is different than the resolved one (8.1.0)`