### PR TITLE
Bugfix: `allSettled` is not registered when `finally` is missing

### DIFF
--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -25,8 +25,11 @@ var globalNS = (function() {
 // https://github.com/taylorhakes/promise-polyfill/issues/114
 if (typeof globalNS['Promise'] !== 'function') {
   globalNS['Promise'] = Promise;
-} else if (!globalNS.Promise.prototype['finally']) {
-  globalNS.Promise.prototype['finally'] = promiseFinally;
-} else if (!globalNS.Promise.allSettled) {
-  globalNS.Promise.allSettled = allSettled;
+} else {
+  if (!globalNS.Promise.prototype['finally']) {
+    globalNS.Promise.prototype['finally'] = promiseFinally;
+  } 
+  if (!globalNS.Promise.allSettled) {
+    globalNS.Promise.allSettled = allSettled;
+  }
 }


### PR DESCRIPTION
On XP Firefox 52, `Promise.prototype.finally` and `Promise.allSettled` are both undefined.

The current polyfill behavior will only register the `finally` fn and not `allSettled`.