### PR TITLE
fix: adapt to the case of incomplete promise implementation

### DIFF
--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -1,9 +1,9 @@
-import Promise from './index';
-import promiseFinally from './finally';
 import allSettled from './allSettled';
+import promiseFinally from './finally';
+import Promise from './index';
 
 /** @suppress {undefinedVars} */
-var globalNS = (function() {
+var globalNS = (function () {
   // the only reliable means to get the global object is
   // `Function('return this')()`
   // However, this causes CSP violations in Chrome apps.
@@ -25,8 +25,10 @@ var globalNS = (function() {
 // https://github.com/taylorhakes/promise-polyfill/issues/114
 if (typeof globalNS['Promise'] !== 'function') {
   globalNS['Promise'] = Promise;
-} else if (!globalNS.Promise.prototype['finally']) {
+}
+if (!globalNS.Promise.prototype['finally']) {
   globalNS.Promise.prototype['finally'] = promiseFinally;
-} else if (!globalNS.Promise.allSettled) {
+}
+if (!globalNS.Promise.allSettled) {
   globalNS.Promise.allSettled = allSettled;
 }


### PR DESCRIPTION
In some environments, the native `Promise` is not complete (for example, the lack of `finally` method), here should use the `if` statement to determine whether these methods and properties exist in turn, instead of using `else if`.