### PR TITLE
fire unhandledrejection event

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -252,6 +252,12 @@ Promise._unhandledRejectionFn = function _unhandledRejectionFn(err) {
   if (typeof console !== 'undefined' && console) {
     console.warn('Possible Unhandled Promise Rejection:', err); // eslint-disable-line no-console
   }
+  if (typeof window !== 'undefined' && window && typeof window.dispatchEvent === "function") {
+    const evt = new CustomEvent("unhandledrejection");
+    evt.reason = err;
+    evt.promise = this;
+    window.dispatchEvent(evt);
+  }
 };
 
 export default Promise;


### PR DESCRIPTION
close #129 

This would work for me.
As alternative to CustomEvent, one could introduce a dedicated PromiseRejectionEvent.