### PR TITLE
IE11 Fix - setImmediate throws "Invalid calling object" error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -242,7 +242,7 @@ Promise._immediateFn =
   (typeof setImmediateFunc === 'function' &&
     function(fn) {
       // @ts-ignore
-      setImmediateFunc(fn);
+      setImmediateFunc.call(window, fn);
     }) ||
   function(fn) {
     setTimeoutFunc(fn, 0);


### PR DESCRIPTION
## Issue
When using the promise-polyfill outside the window context, calling `setImmediate` throws an "Invalid calling object" error.

## Resolution
Provide `window` as the context for the `setImmediate` invocation